### PR TITLE
Fix fstab file name

### DIFF
--- a/udoo_6dq/BoardConfig.mk
+++ b/udoo_6dq/BoardConfig.mk
@@ -9,8 +9,8 @@ ADDITIONAL_BUILD_PROPERTIES += \
 
 BUILD_TARGET_FS ?= ext4
 TARGET_USERIMAGES_USE_EXT4 := true
-TARGET_RECOVERY_FSTAB = device/udoo/udoo_6dq/fstab_sd.freescale
-PRODUCT_COPY_FILES   += device/udoo/udoo_6dq/fstab_sd.freescale:root/fstab.freescale
+TARGET_RECOVERY_FSTAB = device/udoo/udoo_6dq/fstab.freescale
+PRODUCT_COPY_FILES   += device/udoo/udoo_6dq/fstab.freescale:root/fstab.freescale
 
 PRODUCT_MODEL := UDOO-MX6DQ
 


### PR DESCRIPTION
This fix the error:
ninja: error: 'device/udoo/udoo_6dq/fstab_sd.freescale', needed by 'out/target/product/udoo_6dq/root/fstab.freescale', missing and no known rule to make it